### PR TITLE
Update source/plg_system_t3/includes/menu/megamenu.tpl.php

### DIFF
--- a/source/plg_system_t3/includes/menu/megamenu.tpl.php
+++ b/source/plg_system_t3/includes/menu/megamenu.tpl.php
@@ -231,7 +231,7 @@ class T3MenuMegamenuTpl {
 
 		$class .= " separator";
 
-		return "<span class=\"$class\">$icon$title $linktype</span>";
+		return "<a href=\"#\" class=\"$class\">$icon$title $linktype</a>";
 	}
 	static function item_component ($vars) {
 		$item = $vars['item'];


### PR DESCRIPTION
Separators (dummy items) should be link-element, otherwise the styling doesn't work when in level 0 of megamenu.
