### PR TITLE
Adds a check for layout-custom.css in template admin folder.

### DIFF
--- a/source/plg_system_t3/includes/core/admin.php
+++ b/source/plg_system_t3/includes/core/admin.php
@@ -131,6 +131,9 @@ class T3Admin {
 		$jdoc->addStyleSheet(T3_ADMIN_URL . '/includes/depend/css/depend.css');
 		$jdoc->addStyleSheet(T3_ADMIN_URL . '/admin/layout/css/layout-preview.css');
 		$jdoc->addStyleSheet(T3_ADMIN_URL . '/admin/layout/css/layout.css');
+		if(file_exists(T3_TEMPLATE_PATH . '/admin/layout-custom.css')) {
+			$jdoc->addStyleSheet(T3_TEMPLATE_URL . '/admin/layout-custom.css');
+		}
 		$jdoc->addStyleSheet(T3_ADMIN_URL . '/admin/css/admin.css');
 		if(!$jversion->isCompatible('3.0')){
 			$jdoc->addStyleSheet(T3_ADMIN_URL . '/admin/css/admin-j25.css');


### PR DESCRIPTION
In some of our themes the layout panel in the admin isn't displaying
properly or there are some cases where we want to hide certain elements.

This pull request adds a check for layout-custom.css in the template
admin folder which will aloow us to add css to control the display of
the layout in the admin.
