### PR TITLE
Add missing bootstrap error styling

### DIFF
--- a/source/plg_system_t3/base/bootstrap/less/buttons.less
+++ b/source/plg_system_t3/base/bootstrap/less/buttons.less
@@ -150,7 +150,8 @@ input[type="button"] {
   .buttonBackground(@btnWarningBackground, @btnWarningBackgroundHighlight);
 }
 // Danger and error appear as red
-.btn-danger {
+.btn-danger,
+.btn-error {
   .buttonBackground(@btnDangerBackground, @btnDangerBackgroundHighlight);
 }
 // Success appears as green

--- a/source/tpl_t3_blank/less/form.less
+++ b/source/tpl_t3_blank/less/form.less
@@ -1,13 +1,13 @@
-/** 
+/**
  *------------------------------------------------------------------------------
  * @package       T3 Framework for Joomla!
  *------------------------------------------------------------------------------
  * @copyright     Copyright (C) 2004-2013 JoomlArt.com. All Rights Reserved.
  * @license       GNU General Public License version 2 or later; see LICENSE.txt
- * @authors       JoomlArt, JoomlaBamboo, (contribute to this project at github 
+ * @authors       JoomlArt, JoomlaBamboo, (contribute to this project at github
  *                & Google group to become co-author)
  * @Google group: https://groups.google.com/forum/#!forum/t3fw
- * @Link:         http://t3-framework.org 
+ * @Link:         http://t3-framework.org
  *------------------------------------------------------------------------------
  */
 
@@ -436,7 +436,8 @@ button {
 }
 
 // Danger and error appear as red
-.btn-danger {
+.btn-danger,
+.btn-error {
   .buttonBackground(@btnDangerBackgroundHighlight, @btnDangerBackground);
 }
 


### PR DESCRIPTION
Bootstrap styling requires both -danger and -error classes, however .btn-error is missing from two files.
