### PR TITLE
Add type.less back in

### DIFF
--- a/source/tpl_t3_blank/less/bootstrap.less
+++ b/source/tpl_t3_blank/less/bootstrap.less
@@ -21,7 +21,7 @@
 @import "../../../plugins/system/t3/base/bootstrap/less/layouts.less";
 
 // Base CSS
-//@import "../../../plugins/system/t3/base/bootstrap/less/type.less"; // T3 Note: Already in T3 typo.less
+@import "../../../plugins/system/t3/base/bootstrap/less/type.less";
 @import "../../../plugins/system/t3/base/bootstrap/less/code.less";
 @import "../../../plugins/system/t3/base/bootstrap/less/forms.less";
 @import "../../../plugins/system/t3/base/bootstrap/less/tables.less";


### PR DESCRIPTION
typo.less does NOT hold the same information as type.less - so adding
this back in so that we get these classes included.
