### PR TITLE
Prevent div scrollbar on tip display near edge

### DIFF
--- a/source/tpl_t3_blank/less/layout.less
+++ b/source/tpl_t3_blank/less/layout.less
@@ -1,13 +1,13 @@
-/** 
+/**
  *------------------------------------------------------------------------------
  * @package       T3 Framework for Joomla!
  *------------------------------------------------------------------------------
  * @copyright     Copyright (C) 2004-2013 JoomlArt.com. All Rights Reserved.
  * @license       GNU General Public License version 2 or later; see LICENSE.txt
- * @authors       JoomlArt, JoomlaBamboo, (contribute to this project at github 
+ * @authors       JoomlArt, JoomlaBamboo, (contribute to this project at github
  *                & Google group to become co-author)
  * @Google group: https://groups.google.com/forum/#!forum/t3fw
- * @Link:         http://t3-framework.org 
+ * @Link:         http://t3-framework.org
  *------------------------------------------------------------------------------
  */
 
@@ -19,4 +19,15 @@
 .wrap {
   width: auto;
   clear: both;
+}
+
+// Avoid horiz. scroll-bars on tabs when e.g. tooltip is shown near right margin
+.tab-content {
+  overflow: visible; // allow content to exceed div boundaries
+                     // In most web designs, height is left to grow to fit content,
+                     // and text normally wraps within width.
+                     // Bootstrap's auto will result in scroll bars on the div which is unsightly.
+                     // Window scroll bars should activate if needed.
+                     // This should be either visible (to allow e.g. tooltips to overflow into the margins)
+                     // or hidden (in which case e.g. tooltips will be clipped).
 }


### PR DESCRIPTION
I think it is generally accepted in the web design community that in general, scroll bars should be at a window level unless absolutely essential and if you are going to use scroll bars at a lower level that these should be very carefully designed to avoid the creation of a poor UI experience.

Generally you will set overflow to either hidden (so images / tooltips etc. are clipped) or visible (so that they extend outside the div). You would not use auto or scroll which create scroll bars on the div when needed or permanently respectively.

This fix relates to tab-content, which in this template has fixed (empty) left and right margins within the window and variable length. So we should never get vertical overflow, but can get horizontal overflow from tooltips etc.

This fix, changes the overflow for the tab-content from auto (which creates scrollbars) to visible which allows horizontal overflow into the margins for e.g. tooltips.
