### PR TITLE
Update navhelper.php

### DIFF
--- a/source/tpl_t3_bs3_blank/tpls/blocks/navhelper.php
+++ b/source/tpl_t3_bs3_blank/tpls/blocks/navhelper.php
@@ -8,10 +8,12 @@
 defined('_JEXEC') or die;
 ?>
 
-<!-- NAV HELPER -->
-<nav class="wrap t3-navhelper <?php $this->_c('navhelper') ?>">
-	<div class="container">
-		<jdoc:include type="modules" name="<?php $this->_p('navhelper') ?>" />
-	</div>
-</nav>
-<!-- //NAV HELPER -->
+<?php if ($this->countModules('navhelper')) : ?>
+	<!-- NAV HELPER -->
+	<nav class="wrap t3-navhelper <?php $this->_c('navhelper') ?>">
+		<div class="container">
+			<jdoc:include type="modules" name="<?php $this->_p('navhelper') ?>" />
+		</div>
+	</nav>
+	<!-- //NAV HELPER -->
+<?php endif ?>


### PR DESCRIPTION
Remains empty div (nav), when the module is not published in this position (navhelper).
![screenshot_3](https://f.cloud.github.com/assets/3341562/1808532/d211c746-6d5c-11e3-8f61-6d69e877b472.jpg)
