### PR TITLE
removed 'hidden-xs' class from footer spotlight

### DIFF
--- a/source/tpl_t3_bs3_blank/tpls/blocks/footer.php
+++ b/source/tpl_t3_bs3_blank/tpls/blocks/footer.php
@@ -13,7 +13,7 @@ defined('_JEXEC') or die;
 
 	<?php if ($this->checkSpotlight('footnav', 'footer-1, footer-2, footer-3, footer-4, footer-5, footer-6')) : ?>
 		<!-- FOOT NAVIGATION -->
-		<div class="container hidden-xs">
+		<div class="container">
 			<?php $this->spotlight('footnav', 'footer-1, footer-2, footer-3, footer-4, footer-5, footer-6') ?>
 		</div>
 		<!-- //FOOT NAVIGATION -->


### PR DESCRIPTION
The footer modules (footer-1, footer-2, etc.) were hidden in smartphone/tablet mode, even if they were marked as visible in the template layout editor.
