### PR TITLE
Update off-canvas.js

### DIFF
--- a/source/plg_system_t3/base-bs3/js/off-canvas.js
+++ b/source/plg_system_t3/base-bs3/js/off-canvas.js
@@ -13,7 +13,7 @@
 
 jQuery (document).ready(function($){
     // fix for old ie
-    if ($.browser.msie && $.browser.version < 10) {
+    if (/MSIE\s([\d.]+)/.test(navigator.userAgent) ? new Number(RegExp.$1) < 10 : false) {
         $('html').addClass ('old-ie');
     } else if(/constructor/i.test(window.HTMLElement)){
         $('html').addClass('safari');
@@ -136,7 +136,7 @@ jQuery (document).ready(function($){
         }, 550);
 
         // fix for old ie
-        if ($.browser.msie && $.browser.version < 10) {
+        if ($('html').hasClass ('old-ie')) {
             var p1 = {}, p2 = {};
             p1['padding-'+direction] = 0;
             p2[direction] = -$('.t3-off-canvas').width();


### PR DESCRIPTION
do not use $.browser anymore as it is deprecated as of jQuery 1.3 and removed as of jQuery 1.9
