### PR TITLE
Fix (actions.addRow)

### DIFF
--- a/source/plg_system_t3/admin/megamenu/js/megamenu.js
+++ b/source/plg_system_t3/admin/megamenu/js/megamenu.js
@@ -250,7 +250,7 @@ var T3AdminMegamenu = window.T3AdminMegamenu || {};
 
 	actions.addRow = function () {
 		if (!currentSelected) return ;
-		var $row = $('<div class="row-fluid"><div class="span12"><div class="mega-inner"></div></div></div>').appendTo(currentSelected.find('[class*="row"]:first').parent()),
+		var $row = $('<div class="row-fluid"><div class="span12"><div class="mega-inner"></div></div></div>').appendTo(currentSelected),
 		$col = $row.children();
 		// bind event
 		bindEvents ($col);


### PR DESCRIPTION
When the Submenu is empty, the actions.addRow function doesn't work properly in the Megamenu configuration page, basically reloading it instead of adding a row to the Submenu.
Sadly my fix makes it impossible to remove the first row in a non-empty Submenu, so I'll close the pull request and look further into the matter.
