### PR TITLE
Off-Canvas Gltch

### DIFF
--- a/source/plg_system_t3/base-bs3/less/megamenu.less
+++ b/source/plg_system_t3/base-bs3/less/megamenu.less
@@ -392,7 +392,7 @@
             -moz-backface-visibility: hidden;
             -o-backface-visibility: hidden;
             backface-visibility: hidden;            
-            margin-top: -100%;
+            margin-top: -10%;
           }
         }
         &.open > .mega-dropdown-menu {


### PR DESCRIPTION
when a flyout on the mainmenu is opened, there is an overflow of the hidden div animation which reveals itself on top of the mainmenu. In other words, when the submenu flys in from the top, the text rides on top of the parent menu container. It looks just a little sloppy