### PR TITLE
Off-Canvas Gltch

### DIFF
--- a/source/plg_system_t3/base-bs3/less/megamenu.less
+++ b/source/plg_system_t3/base-bs3/less/megamenu.less
@@ -168,7 +168,7 @@
 
   // Nav in Group
   .mega-group > .mega-nav,
-  .dropdown-menu .mega-group > .mega-nav {
+  .dropdown-menu .mega-group > .mega-nav {-
     margin-left: -5px;
     margin-right: -5px;
   }
@@ -394,7 +394,7 @@
           > div {
             .transition(all 400ms);
             .backface-visibility(hidden);            
-            margin-top: -100%;
+            margin-top: -10%;
           }
         }
 


### PR DESCRIPTION
Off-Canvas Gltch
 when a flyout on the mainmenu is opened, there is an overflow of the hidden div animation which reveals itself on top of the mainmenu. In other words, when the submenu flys in from the top, the text rides on top of the parent menu container. It looks just a little sloppy