### PR TITLE
remove unnecessary mysql specific backticks

### DIFF
--- a/source/plg_system_t3/t3.php
+++ b/source/plg_system_t3/t3.php
@@ -53,9 +53,9 @@ class plgSystemT3 extends JPlugin
 					$query = $db->getQuery(true);
 					$query
 						->select('home, template, params')
-						->from('`#__template_styles`')
-						->where('`client_id` = 0 AND `id`= ' . (int)$t3tmid)
-						->order('`id` ASC');
+						->from('#__template_styles')
+						->where('client_id = 0 AND id= ' . (int)$t3tmid)
+						->order('id ASC');
 					$db->setQuery($query);
 					$tm = $db->loadObject();
 

--- a/source/plg_system_t3/t3.script.php
+++ b/source/plg_system_t3/t3.script.php
@@ -26,10 +26,10 @@ class plgSystemT3InstallerScript
         $query = $db->getQuery(true);
         $query
             ->update('#__extensions')
-            ->set("`enabled`='1'")
-            ->where("`type`='plugin'")
-            ->where("`folder`='system'")
-            ->where("`element`='t3'");
+            ->set("enabled='1'")
+            ->where("type='plugin'")
+            ->where("folder='system'")
+            ->where("element='t3'");
         $db->setQuery($query);
         $db->execute();
         


### PR DESCRIPTION
Trying to install template and plugins on a Joomla install on IIS7 with SQLServer. Needed to remove backticks to get it to work properly.