### PR TITLE
Resolve Overrides Language Constant (Issue #403)

### DIFF
--- a/source/plg_system_t3/base-bs3/params/template.xml
+++ b/source/plg_system_t3/base-bs3/params/template.xml
@@ -232,8 +232,8 @@
 				<option value="click">T3_NAVIGATION_TRIG_CLICK</option>
 			</field>
 
-			<field name="navigation_mm_legend" type="t3depend" function="@legend" label="T3_NAVIGATION_MM_GROUP_LABEL"
-						 description="T3_NAVIGATION_MM_GROUP_DESC"/>
+			<field name="navigation_mm_legend" type="t3depend" function="@legend" label="T3_NAVIGATION_MM_CONFIG_GROUP_LABEL"
+						 description="T3_NAVIGATION_MM_CONFIG_GROUP_DESC"/>
 
 			<field name="navigation_type" type="radio" class="t3onoff" default="megamenu"
 						 global="1"


### PR DESCRIPTION
The one Language Constant "T3_NAVIGATION_MM_GROUP_DESC" are used two times at different menus. First time in Main BS3 Templates Settings - "Navigation" Tab (this file), second time in Megamenu settings (file plg_system_t3\admin\megamenu\megamenu.tpl)