### PR TITLE
Fix for PostgreSQL.

### DIFF
--- a/source/plg_system_t3/includes/core/bot.php
+++ b/source/plg_system_t3/includes/core/bot.php
@@ -320,7 +320,7 @@ class T3Bot extends JObject
 				';
 							foreach ($extras as $extra) {
 								$_xml .= '
-							<field name="theme_extras_'.$extra.'" global="1" type="menuitem" multiple="true" default="" label="'.$extra.'" description="'.$extra.'" published="true" class="t3-extra-setting">
+							<field name="theme_extras_'.$extra.'" global="1" type="menuitem" multiple="true" default="" label="'.$extra.'" description="'.$extra.'" published="1" class="t3-extra-setting">
 									<option value="-1">T3_ADDON_THEME_EXTRAS_ALL</option>
 									<option value="0">T3_ADDON_THEME_EXTRAS_NONE</option>
 							</field>';


### PR DESCRIPTION
Using Joomla 3.4.4 on PostgreSQL (also tested Joomla version under development) and trying to edit Purity III template, I obtained:
![error-1-duplicar-template](https://cloud.githubusercontent.com/assets/701221/9751039/45158b4a-5665-11e5-8f3f-9de2d1a63f27.png)

I though the problem was in Joomla, and started issue there:
https://github.com/joomla/joomla-cms/issues/7834

Then I found solution sanitizing parameters of a function in Joomla
https://github.com/joomla/joomla-cms/pull/7843

Later with help of @Bakual found that the problem came from T3 and finally found this solution.