### PR TITLE
Fix anchor error on mobile

### DIFF
--- a/source/plg_system_t3/base-bs3/js/off-canvas.js
+++ b/source/plg_system_t3/base-bs3/js/off-canvas.js
@@ -195,8 +195,9 @@ jQuery (document).ready(function($){
                 setTimeout(function(){
                     var anchor = $("a[name='"+ arr1[1] +"']");
                     if (!anchor.length) anchor = $('#' + arr1[1]);
-                    $('html,body').animate({scrollTop: anchor.offset().top},'slow');
-                }, 500);
+                    if (anchor.length) 
+                        $('html,body').animate({scrollTop: anchor.offset().top},'slow');
+                }, 1000);
             }
         }
         stopBubble(e);


### PR DESCRIPTION
- do nothing when anchor undefined
- increase waiting time to get full offset