### PR TITLE
Update minify.php

### DIFF
--- a/source/plg_system_t3/includes/core/minify.php
+++ b/source/plg_system_t3/includes/core/minify.php
@@ -396,8 +396,7 @@ class T3Minify
 
 				$output[$outputurl . '/' . $groupname] = array(
 					'mime' => 'text/css',
-					'media' => $media,
-					'attribs' => array()
+					'media' => $media
 					);
 			}
 		}


### PR DESCRIPTION
Error: Attribute attribs not allowed on element link at this point. 
Checked at https://validator.w3.org

Attribute attribs not allowed on element link at this point.

<link href="/vp-assets/css/css-723e5-86028.css" rel="stylesheet" type="text/css" media="all" attribs="[]" />
to 
<link href="/vp-assets/css/css-723e5-86028.css" rel="stylesheet" type="text/css" media="all" />