### PR TITLE
Use label's 'for' attribute rather than prev() when building t3onoff

### DIFF
--- a/source/plg_system_t3/base-bs3/js/frontend-edit.js
+++ b/source/plg_system_t3/base-bs3/js/frontend-edit.js
@@ -24,7 +24,7 @@
 
 		//add class on/off
 		$('fieldset.t3onoff').find('label').addClass(function(){
-			var $this = $(this), $input = $this.prev('input'),
+			var $this = $(this), $input = $('#' + $this.attr('for')),
 			cls = $this.hasClass('off') || $input.val() == '0' ? 'off' : 'on';
 			cls += $input.prop('checked') ? ' active' : '';
 			return cls;

--- a/source/plg_system_t3/base/js/frontend-edit.js
+++ b/source/plg_system_t3/base/js/frontend-edit.js
@@ -24,7 +24,7 @@
 
 		//add class on/off
 		$('fieldset.t3onoff').find('label').addClass(function(){
-			var $this = $(this), $input = $this.prev('input'),
+			var $this = $(this), $input = $('#' + $this.attr('for')),
 			cls = $this.hasClass('off') || $input.val() == '0' ? 'off' : 'on';
 			cls += $input.prop('checked') ? ' active' : '';
 			return cls;


### PR DESCRIPTION
As-is, the code breaks any on/off radio fieldset that doesn't have the input before the label.  This change uses the 'for' attribute of the label to find the input, rather than relying on the DOM structure using prev().

Note that existing code already does this in the listener on line 36, so already assumes there is a 'for' property.