### PR TITLE
Prevent removing all attributes of body tag

### DIFF
--- a/source/plg_system_t3/includes/core/template.php
+++ b/source/plg_system_t3/includes/core/template.php
@@ -587,7 +587,7 @@ class T3Template extends ObjectExtendable
 		}
 		if (($openbody = $this->getParam('snippet_open_body', ''))) {
 			$places[] = '@^\s*<body[^>]*>\s*$@msU';
-			$contents[] = "<body>\n" . $openbody;
+			$contents[] = "$0\n" . $openbody;
 		}
 
 		// append modules in debug position


### PR DESCRIPTION
Adding code to "After <body>" will remove all existed attributes of <body>.