### PR TITLE
Hidden Sub-menu item breaks menu structure

### DIFF
--- a/source/plg_system_t3/includes/menu/t3bootstrap.php
+++ b/source/plg_system_t3/includes/menu/t3bootstrap.php
@@ -43,9 +43,9 @@ class T3Bootstrap
 			ob_start();
 			T3BootstrapTpl::render($this->getList());
 			$this->menu = ob_get_contents();
-			ob_end_clean();	
+			ob_end_clean();
 		}
-		
+
 		return $this->menu;
 	}
 
@@ -59,10 +59,19 @@ class T3Bootstrap
 
 		// Get active menu item
 		$items = $menu->getItems('menutype', $this->menutype);
+		$hidden_parents = array();
 		$lastitem = 0;
 
 		if ($items) {
 			foreach ($items as $i => $item) {
+
+				// Exclude item with menu item option 'Display in Menu' set to 'No' - #522
+				if (($item->params->get('menu_show', 1) == 0) || in_array($item->parent_id, $hidden_parents))
+				{
+					$hidden_parents[] = $item->id;
+					unset($items[$i]);
+					continue;
+				}
 
 				$item->deeper = false;
 				$item->shallower = false;

--- a/source/plg_system_t3/includes/menu/t3bootstrap.tpl.php
+++ b/source/plg_system_t3/includes/menu/t3bootstrap.tpl.php
@@ -24,10 +24,6 @@ class T3BootstrapTpl
 		<ul class="nav navbar-nav">
 			<?php
 			foreach ($list as &$item) :
-				//intergration with new params joomla 3.6.x (menu_show)
-				$menu_show = (int)$item->params->get('menu_show', 1);
-				if ($menu_show!=1)
-					continue;
 				$class = 'item-' . $item->id;
 				if ($item->id == $active_id) {
 					$class .= ' current';


### PR DESCRIPTION
If the last item in sub-menu has Display in Menu set to No, the entire menu structure breaks, with no menu items parsed after the menu_show!=1 is found.