### PR TITLE
Itemid added to the link for Joomla 4+

### DIFF
--- a/source/plg_system_t3/includes/menu/t3bootstrap.php
+++ b/source/plg_system_t3/includes/menu/t3bootstrap.php
@@ -108,6 +108,11 @@ class T3Bootstrap
 								$item->flink .= '&Itemid=' . $item->id;
 							}
 						}
+                        else
+                        {
+                            if(strpos($item->flink,'Itemid=') === false)
+                                $item->flink .= (strpos($item->flink,'?') === false ? '?' : '&').'Itemid=' . $item->id;
+                        }
 						
 						break;
 				}


### PR DESCRIPTION
$router->getMode() is deprecated but Itemid is needed for the router.